### PR TITLE
minor updates to logging

### DIFF
--- a/src/antdongle.py
+++ b/src/antdongle.py
@@ -14,15 +14,8 @@ import time
 
 import structconstants      as sc
 
+
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logHandler = logging.StreamHandler()
-filelogHandler = logging.FileHandler("logs.log")
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logHandler.setFormatter(formatter)
-filelogHandler.setFormatter(formatter)
-logger.addHandler(filelogHandler)
-logger.addHandler(logHandler)
 
 # ---------------------------------------------------------------------------
 # Our own choice what channels are used

--- a/src/ble.py
+++ b/src/ble.py
@@ -1,7 +1,6 @@
 import dbus
 
 import logging
-#import sys
 
 DBUS_OM_IFACE = "org.freedesktop.DBus.ObjectManager"
 DBUS_PROP_IFACE = "org.freedesktop.DBus.Properties"
@@ -17,14 +16,6 @@ BLUEZ_SERVICE_NAME = "org.bluez"
 GATT_MANAGER_IFACE = "org.bluez.GattManager1"
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logHandler = logging.StreamHandler()
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logHandler.setFormatter(formatter)
-logger.addHandler(logHandler)
-
-logger.setLevel(logging.DEBUG)
-
 
 class InvalidArgsException(dbus.exceptions.DBusException):
     _dbus_error_name = "org.freedesktop.DBus.Error.InvalidArgs"

--- a/src/logging.conf
+++ b/src/logging.conf
@@ -1,0 +1,33 @@
+# Configuration file format is described in the python documentation:
+# https://docs.python.org/3/library/logging.config.html#configuration-file-format
+#
+# The root logger is currently configured to write info logs to stdout and debug logs
+# to a local file named "pirowflo.log"
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler,logFileHandler
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler,logFileHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=INFO
+formatter=simpleFormatter
+args=(sys.stdout,)
+
+[handler_logFileHandler]
+class=FileHandler
+level=DEBUG
+formatter=simpleFormatter
+args=("pirowflo.log",)
+
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+#datefmt=

--- a/src/smartrowreader.py
+++ b/src/smartrowreader.py
@@ -4,14 +4,6 @@ import threading
 from time import time
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logHandler = logging.StreamHandler()
-filelogHandler = logging.FileHandler("logs.log")
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logHandler.setFormatter(formatter)
-filelogHandler.setFormatter(formatter)
-logger.addHandler(filelogHandler)
-logger.addHandler(logHandler)
 
 #This SDK requires you to create subclasses of gatt.DeviceManager and gatt.Device. The other two classes gatt.Service and gatt.Characteristic are not supposed to be subclassed.
 

--- a/src/smartrowtobleant.py
+++ b/src/smartrowtobleant.py
@@ -9,16 +9,7 @@ import time
 
 import smartrowreader
 
-
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logHandler = logging.StreamHandler()
-filelogHandler = logging.FileHandler("logs.log")
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logHandler.setFormatter(formatter)
-filelogHandler.setFormatter(formatter)
-logger.addHandler(filelogHandler)
-logger.addHandler(logHandler)
 
 
 class DataLogger():

--- a/src/waterrowerble.py
+++ b/src/waterrowerble.py
@@ -48,18 +48,7 @@ LE_ADVERTISEMENT_IFACE = "org.bluez.LEAdvertisement1"
 BLUEZ_SERVICE_NAME = "org.bluez"
 GATT_MANAGER_IFACE = "org.bluez.GattManager1"
 
-
-
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logHandler = logging.StreamHandler()
-filelogHandler = logging.FileHandler("logs.log")
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logHandler.setFormatter(formatter)
-filelogHandler.setFormatter(formatter)
-logger.addHandler(filelogHandler)
-logger.addHandler(logHandler)
-
 
 mainloop = None
 

--- a/src/waterrowerinterface.py
+++ b/src/waterrowerinterface.py
@@ -7,19 +7,12 @@
 # -*- coding: utf-8 -*-
 import threading
 import logging
+
 import time
 import serial
 import serial.tools.list_ports
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logHandler = logging.StreamHandler()
-filelogHandler = logging.FileHandler("logs.log")
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logHandler.setFormatter(formatter)
-filelogHandler.setFormatter(formatter)
-logger.addHandler(filelogHandler)
-logger.addHandler(logHandler)
 
 MEMORY_MAP = {'055': {'type': 'total_distance_m', 'size': 'double', 'base': 16},
               '140': {'type': 'total_strokes', 'size': 'double', 'base': 16},

--- a/src/waterrowerthreads.py
+++ b/src/waterrowerthreads.py
@@ -22,6 +22,7 @@ python3 waterrowerthreads.py -i s4 -b -a
 """
 
 import logging
+import logging.config
 import threading
 import argparse
 from queue import Queue
@@ -32,19 +33,10 @@ import wrtobleant
 import waterrowerant
 import smartrowtobleant
 
-
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logHandler = logging.StreamHandler()
-filelogHandler = logging.FileHandler("logs.log")
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logHandler.setFormatter(formatter)
-filelogHandler.setFormatter(formatter)
-logger.addHandler(filelogHandler)
-logger.addHandler(logHandler)
-
 
 def main(args=None):
+    logging.config.fileConfig('logging.conf', disable_existing_loggers=False)
 
     def BleService(out_q, ble_in_q):
         logger.info("Start BLE Advertise and BLE GATT Server")

--- a/src/wrtobleant.py
+++ b/src/wrtobleant.py
@@ -12,15 +12,6 @@ import numpy
 import waterrowerinterface
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-logHandler = logging.StreamHandler()
-filelogHandler = logging.FileHandler("logs.log")
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logHandler.setFormatter(formatter)
-filelogHandler.setFormatter(formatter)
-logger.addHandler(filelogHandler)
-logger.addHandler(logHandler)
-
 '''
 We register 3 callback function to the WaterrowerInterface with the event as input. Those function get exectuted 
 as soon as an event is register from "capturing". 


### PR DESCRIPTION
This change eliminates some duplicated boilerplate code that relates to logging in the global section of many python files. Instead of configuring logging though code we now read logging.conf 

The default logging.conf file writes info level logs to stdout and debug logs to pirowflo.log.