### PR TITLE
create member variables in __init__

### DIFF
--- a/src/smartrowtobleant.py
+++ b/src/smartrowtobleant.py
@@ -29,6 +29,13 @@ class DataLogger():
         self._rower_interface = rower_interface
         self._rower_interface.register_callback(self.on_row_event)
 
+        self.WRValues_rst = None
+        self.WRValues = None
+        self.WRValues_standstill = None
+        self.starttime = None
+        self.fullstop = None
+        self.SmartRowHalt = None
+
         self._reset_state()
 
     def _reset_state(self):

--- a/src/wrtobleant.py
+++ b/src/wrtobleant.py
@@ -35,6 +35,29 @@ class DataLogger(object):
         self._rower_interface.register_callback(self.on_rower_event)
         self._stop_event = threading.Event()
 
+        self._InstaPowerStroke = None
+        self.maxpowerStroke = None
+        self._StrokeStart = None
+        self.Watts = None
+        self._maxpowerfivestrokes = None
+        self.AvgInstaPower = None
+        self.Lastcheckforpulse = None
+        self.PulseEventTime = None
+        self.InstantaneousPace = None
+        self.DeltaPulse = None
+        self.PaddleTurning = None
+        self.rowerreset = None
+        self.WRValues_rst = None
+        self.WRValues = None
+        self.WRValues_standstill = None
+        self.BLEvalues = None
+        self.ANTvalues = None
+        self.secondsWR = None
+        self.minutesWR = None
+        self.hoursWR = None
+        self.elapsetime = None
+        self.elapsetimeprevious = None
+
         self._reset_state()
 
     def _reset_state(self):


### PR DESCRIPTION
Hi @inonoob ,
I shouldn't have hid the creation of these member variables under _reset_state(). Now, I create them in __init__(), and assign the initial values in the _reset_state().

It will conflict with your starttime = time.time(), so after we figure the best way for that, I can update this PR.

- Benjamin