### PR TITLE
Update wrtobleant.py

### DIFF
--- a/src/adapters/s4/wrtobleant.py
+++ b/src/adapters/s4/wrtobleant.py
@@ -164,10 +164,9 @@ class DataLogger(object):
     def TimeElapsedcreator(self):
         self.elapsetime = datetime.timedelta(seconds=self.secondsWR, minutes=self.minutesWR, hours=self.hoursWR)
         self.elapsetime = int(self.elapsetime.total_seconds())
-        if  self.elapsetime >= self.elapsetimeprevious:
         # print('sec:{0};min:{1};hr:{2}'.format(self.secondsWR,self.minutesWR,self.hoursWR))
-            self.WRValues.update({'elapsedtime': self.elapsetime})
-            self.elapsetimeprevious = self.elapsetime
+        self.WRValues.update({'elapsedtime': self.elapsetime})
+        self.elapsetimeprevious = self.elapsetime
 
     def WRValuesStandstill(self):
         self.WRValues_standstill = deepcopy(self.WRValues)


### PR DESCRIPTION
Removed if, because of a race condition. Sometimes, comes the minute change before the seconds, and so the time kept hanging, until the next minute change:
1) real time change from 01:59 to 02:00
2) Sometimes the minute change arrives before the second, so the pirowflo has 02:59
3) Because of the removed if, the time didn't update until 03:00