### PR TITLE
Added apt install libdbus-1-dev requirement to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,7 @@ sudo apt-get install -y \
     gir1.2-gtk-3.0 \
     python3-pip \
     libatlas-base-dev \
+    libdbus-1-dev \
     libglib2.0-dev \
     libgirepository1.0-dev \
     libcairo2-dev \


### PR DESCRIPTION
On a new clean Raspberry Pi OS install on a RPi 3, I found I needed to install this to avoid subsequent pip install errors during the install.sh script.